### PR TITLE
Modify CREATE2 opcode -> 0xf5

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,9 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 | `0xf2` | CALLCODE | Message-call into this account with alternative account's code | - | Complicated |
 | `0xf3` | RETURN | Halt execution returning output data | - | 0 |
 | `0xf4` | DELEGATECALL | Message-call into this account with an alternative account's code, but persisting into this account with an alternative account's code | - | Complicated |
-| `0xf5` | CALLBLACKBOX | - | - | | 40 | 
+| `0xf5` | CREATE2 | Create a new account and set creation address to `sha3(sender + sha3(init code)) % 2**160` | - |
 | `0xf6` - `0xf9` | Unused | - | - |
 | `0xfa` | STATICCALL | Similar to CALL, but does not modify state | - | 40 |
-| `0xfb` | CREATE2 | Create a new account and set creation address to `sha3(sender + sha3(init code)) % 2**160` | - |
 | `0xfc` | TXEXECGAS | Not in yellow paper FIXME | - | - |
 | `0xfd` | REVERT | Stop execution and revert state changes, without consuming all provided gas and providing a reason | - | 0 |
 | `0xfe` | INVALID | Designated invalid instruction | - | 0 |


### PR DESCRIPTION
`CREATE2` is located at `0xf5`, as spec'd at [EIP-1014](https://github.com/ethereum/EIPs/blob/b9c28ee05f3d1f8ea2f9ed138954a6672a02051e/EIPS/eip-1014.md#specification) and as implemented at https://github.com/ethereum/go-ethereum/blob/master/core/vm/opcodes.go#L213.