### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The gas information is a work in progress. If an asterisk is in the Gas column, 
 
 ## Table
 
-| Opcode | Name | Description | Extra Info | Gas |
+| Bytecode | Name (Opcode) | Description | Extra Info | Gas |
 | --- | --- | --- | --- | --- |
 | `0x00` | STOP | Halts execution | - | 0 |
 | `0x01` | ADD | Addition operation | - | 3 |


### PR DESCRIPTION
`0x00`, `0x01` are usually bytecode and not the opcodes, In reality opcodes are PUSH1, DUP1 etc. as far as I am concerned